### PR TITLE
fix backlinks, don't redraw convos on each post

### DIFF
--- a/public/chat.js
+++ b/public/chat.js
@@ -78,24 +78,22 @@ function swap_to_convo(convo){
 }
 
 function draw_convos(){
-	$('.sidebar:first').html('');
+    $('.sidebar:first').empty();
 
-	for(i in convos){
-		
-	    var div = $("<div class='sidebar_convo'/>");
-		div.text(convos[i]);
-		div.click(function() {
-		swap_to_convo($(this).text());
-		});
-		$('.sidebar:first').prepend(div);
-	}
-		
-	div = $("<div class='sidebar_convo'>All</div>");
-	div.click(function() {
-		swap_to_convo("");
-	});
-	$('.sidebar:first').prepend(div);
+    var div = $("<div class='sidebar_convo'>All</div>");
+    div.click(function() {
+        swap_to_convo("");
+    });
+    $('.sidebar:first').append(div);
 
+    for (var i = 0; i < convos.length && i < 20; i++) {
+        div = $("<div class='sidebar_convo'/>");
+        div.text(convos[convos.length - 1 - i]);
+        div.click(function() {
+            swap_to_convo($(this).text());
+        });
+        $('.sidebar:first').append(div);
+    }
 }
 
 function generate_post(id) {
@@ -333,9 +331,6 @@ function update_chat(new_data, first_load) {
         } else {
             convos.splice(convo_index,1);
             convos.push(data.convo);
-        }
-        if (convos.length > 20) {
-            convos.splice(0,1);
         }
         if (!first_load) draw_convos();
         notifications(data.convo);

--- a/public/main.js
+++ b/public/main.js
@@ -324,8 +324,10 @@ function quote(id) {
     }
 
     // set conversation
-    $("#convo").val(chat[id].convo);
-    apply_filter();
+    if ($.inArray(get_convo(), convos) > -1) {
+        $("#convo").val(chat[id].convo);
+        apply_filter();
+    }
 }
 
 function notifications(post_convo) {


### PR DESCRIPTION
Fixes the double backlinking bug I accidentally introduced.
Speeds up page loading.  Also various minor fixes.
~~Third commit makes it so quoting a post always change to that conversation (previously it only happened if you weren't in a conversation already, and the new conversation wasn't "General").~~
Revised: Quoting a post always changes to that conversation unless you have something in the convo field not in the current list.  The presumption is that you typed it in yourself and want to change the conversation topic.
