### PR TITLE
Update tripcode to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ipfilter": "~0.0.4",
     "logfmt": "~0.18.1",
     "socket.io": "~0.9.16",
-    "tripcode": "~1.1.0",
+    "tripcode": "~1.2.0",
     "mongoose": "*",
     "gm": "*"
   },


### PR DESCRIPTION
Just released tripcode [1.2.0](https://github.com/KenanY/tripcode/releases/tag/1.2.0), which fixes a bug where generated tripcodes from passwords with a single quote (`'`) were incorrect.
