### PR TITLE
check file extension against contents, try another method of checking transparency

### DIFF
--- a/config.js
+++ b/config.js
@@ -32,7 +32,6 @@ module.exports = {
     video_formats: ['ogv', 'webm'],
     audio_formats: ['ogg'],
 
-    format_names: ['ogg', 'matroska,webm'],
     codec_names: {
         video: ['theora', 'vp8', 'vp9'],
         audio: ['vorbis', 'libopus']

--- a/lib/utils/format-image.js
+++ b/lib/utils/format-image.js
@@ -4,8 +4,20 @@ var path = require('path');
 var spawn = require('child_process').spawn;
 var fs = require('fs');
 
+var get_extension = require('./get-extension');
 var categorize = require('./categorize');
 var config = require('../../config');
+
+// format names returned by identify/ffprobe
+var format_names = {
+    'gif': 'GIF',
+    'jpg': 'JPEG',
+    'jpeg': 'JPEG',
+    'png': 'PNG',
+    'ogg': 'ogg',
+    'ogv': 'ogg',
+    'webm': 'matroska,webm'
+};
 
 /* format_image
     - reads metadata of uploaded file
@@ -19,13 +31,16 @@ module.exports = function(data, callback) {
         }
 
         /* is this an image/video/audio file? */
+        var extension = get_extension(data.image);
         var category = categorize(data.image);
 
         /* prepare command to read metadata */
         var command, args;
         if (category === 'image') {
             command = 'identify';
-            args = '-format [%W,%H,%T,"%A"], -'.split(' ');
+            args = '-format ["%m",%w,%h,0,"true"], -'.split(' ');
+            if (extension === 'gif') args[1] = '["%m",%W,%H,%T,"%[opaque]"],';
+            if (extension === 'png') args[1] = '["%m",%w,%h,0,"%[opaque]"],';
         } else if (category === 'video' || category === 'audio') {
             command = 'ffprobe';
             args = '-print_format json -show_format -show_streams'.split(' ');
@@ -70,13 +85,17 @@ module.exports = function(data, callback) {
                     console.log('identify did not return metadata', stderr);
                     return callback(new Error('metadata_error_03'));
                 }
-                data.image_width = metadata[0][0];
-                data.image_height = metadata[0][1];
-                data.image_transparent = (metadata[0][3].toLowerCase() === "true");
+                if (metadata[0][0] !== format_names[extension]) {
+                    console.log('image file content does not match extension');
+                    return callback(new Error('image file content does not match extension'));
+                }
+                data.image_width = metadata[0][1];
+                data.image_height = metadata[0][2];
+                data.image_transparent = (metadata[0][4].toLowerCase() === "false");
                 if (metadata.length > 1) {
                     data.duration = 0;
                     metadata.forEach(function(x) {
-                        data.duration += x[2] / 100;
+                        data.duration += x[3] / 100;
                     });
                 }
                 return callback();
@@ -86,9 +105,9 @@ module.exports = function(data, callback) {
                     console.log('ffprobe output missing format/streams info');
                     return callback(new Error('ffprobe output missing format/streams info'));
                 }
-                if (config.format_names.indexOf(metadata.format.format_name) < 0) {
-                    console.log('unrecognized format', metadata.format.format_name);
-                    return callback(new Error('unrecognized format'));
+                if (metadata.format.format_name !== format_names[extension]) {
+                    console.log('video file content does not match extension');
+                    return callback(new Error('video file content does not match extension'));
                 }
                 for (var i in metadata.streams) {
                     var codec_names = config.codec_names[metadata.streams[i].codec_type];
@@ -136,15 +155,15 @@ module.exports = function(data, callback) {
                         callback();
                     } else {
                         console.log('ffprobe could not find video stream', stderr);
-                        return callback(new Error('metadata_error_06'));
+                        return callback(new Error('file does not contain video (is this an audio file?)'));
                     }
                 } else {
                     /* audio */
                     if (video_stream === null) {
                         callback();
                     } else {
-                        console.log('expected audio only, got video', stderr);
-                        return callback(new Error('metadata_error_07'));
+                        console.log('expected audio only, found video', stderr);
+                        return callback(new Error('expected audio only, found video'));
                     }
                 }
             }


### PR DESCRIPTION
Let's see if %[opaque] works any better than %A.  If it's worse, we should change that part back.
